### PR TITLE
JetBrains file templates for Kotlin, C, Cpp, and Python

### DIFF
--- a/Jetbrains-templates/CLion/fileTemplates/Leetcode_C_and_Cpp.h
+++ b/Jetbrains-templates/CLion/fileTemplates/Leetcode_C_and_Cpp.h
@@ -1,0 +1,9 @@
+#[[#include]]# <vector>
+#set($Class_name = ${StringUtils.removeAndHump(${Name}, "_")})
+#set ($Method = ${StringUtils.removeAndHump(${Method_name},"_")} )
+#set($Pascal_case_method = "$Method.substring(0,1).toUpperCase()$Method.substring(1)")
+
+class ${Class_name} {
+public:
+    int ${Pascal_case_method}(const std::vector<int> & input);
+};

--- a/Jetbrains-templates/CLion/fileTemplates/Leetcode_C_and_Cpp.h.child.0.cpp
+++ b/Jetbrains-templates/CLion/fileTemplates/Leetcode_C_and_Cpp.h.child.0.cpp
@@ -1,0 +1,15 @@
+#[[#include]]# <iostream>
+#[[#include]]# "${Name.replaceAll("([a-z])([A-Z]+)","$1_$2").toLowerCase()}.h"
+#set($Class_name = ${StringUtils.removeAndHump(${Name}, "_")})
+#set ($Method = ${StringUtils.removeAndHump(${Method_name},"_")} )
+#set($Pascal_case_method = "$Method.substring(0,1).toUpperCase()$Method.substring(1)")
+
+using namespace std;
+
+int ${Class_name}::${Pascal_case_method}(const vector<int> &input) {
+    int result = 0;
+    for (const auto &record: input) {
+        cout << record;
+    }
+    return result;
+}

--- a/Jetbrains-templates/CLion/fileTemplates/Leetcode_C_and_Cpp.h.child.1.c
+++ b/Jetbrains-templates/CLion/fileTemplates/Leetcode_C_and_Cpp.h.child.1.c
@@ -1,0 +1,10 @@
+#set($Method =${Method_name.replaceAll("([a-z])([A-Z]+)","$1_$2").toLowerCase()} )
+#[[#include]]# <stdio.h>
+
+int ${Method}(int *input, int len) {
+    int result = 0;
+    for (int i = 0; i < len; i++) {
+        printf(input[i]);
+    }
+    return result;
+}

--- a/Jetbrains-templates/CLion/fileTemplates/Leetcode_C_and_Cpp.h.child.2.cpp
+++ b/Jetbrains-templates/CLion/fileTemplates/Leetcode_C_and_Cpp.h.child.2.cpp
@@ -1,0 +1,46 @@
+#set($Class_name = ${StringUtils.removeAndHump(${Name}, "_")})
+#set($Test_class_name = ${StringUtils.removeAndHump(${Name}, "_").concat("Test")})
+#set($Test_data = ${StringUtils.removeAndHump(${Name}, "_").concat("Test").concat("_test_data")})
+#set($Method = ${StringUtils.removeAndHump(${Method_name},"_")} )
+#set($Cpp_method = "$Method.substring(0,1).toUpperCase()$Method.substring(1)")
+#set($C_method = ${Method_name.replaceAll("([a-z])([A-Z]+)","$1_$2").toLowerCase()})
+#set($Dir_path = ${DIR_PATH.replace("src/","").concat("/").concat(${Name.replaceAll("([a-z])([A-Z]+)","$1_$2").toLowerCase()})})
+#[[#include]]# <iostream>
+#[[#include]]# <vector>
+
+#[[#include]]# "gtest/gtest.h"
+#[[#include]]# "${Dir_path}.h"
+#[[#include]]# "${Dir_path}.c"
+
+struct ${Test_data} {
+    std::vector<int> input;
+    int expected;
+};
+
+struct ${Test_class_name} : public testing::TestWithParam<${Test_data}> {
+};
+
+INSTANTIATE_TEST_SUITE_P(${Test_class_name}TestCases, ${Test_class_name},
+                         testing::Values(
+                            ${Test_data}
+                                {{0}, 0}
+                         )
+);
+
+TEST_P(${Test_class_name}, ${Test_class_name}CppTestCase) {
+    auto input = GetParam().input;
+    auto const &expected = GetParam().expected;
+
+    auto actual = ${Class_name}().${Cpp_method}(input);
+    
+    ASSERT_EQ(actual, expected);
+}
+
+TEST_P(${Test_class_name}, ${Test_class_name}CTestCase) {
+    auto input = GetParam().input;
+    auto const &expected = GetParam().expected;
+    
+    int actual = ${C_method}(input.data(), input.size());
+    
+    ASSERT_EQ(actual, expected);
+}

--- a/Jetbrains-templates/CLion/options/file.template.settings.xml
+++ b/Jetbrains-templates/CLion/options/file.template.settings.xml
@@ -1,0 +1,14 @@
+<application>
+  <component name="ExportableFileTemplateSettings">
+    <default_templates>
+      <template name="Leetcode_C_and_Cpp.h" file-name="${Name.replaceAll(&quot;([a-z])([A-Z]+)&quot;,&quot;$1_$2&quot;).toLowerCase()}" reformat="true" live-template-enabled="false">
+        <template name="Leetcode_C_and_Cpp.h.child.0.cpp" file-name="${Name.replaceAll(&quot;([a-z])([A-Z]+)&quot;,&quot;$1_$2&quot;).toLowerCase()}" reformat="true" live-template-enabled="false" />
+        <template name="Leetcode_C_and_Cpp.h.child.1.c" file-name="${Name.replaceAll(&quot;([a-z])([A-Z]+)&quot;,&quot;$1_$2&quot;).toLowerCase()}" reformat="true" live-template-enabled="false" />
+        <template name="Leetcode_C_and_Cpp.h.child.2.cpp" file-name="${Name.replaceAll(&quot;([a-z])([A-Z]+)&quot;,&quot;$1_$2&quot;).toLowerCase()}_test" reformat="true" live-template-enabled="false" />
+      </template>
+      <template name="Leetcode_C_and_Cpp.h.child.0.cpp" file-name="${Name.replaceAll(&quot;([a-z])([A-Z]+)&quot;,&quot;$1_$2&quot;).toLowerCase()}" reformat="true" live-template-enabled="false" />
+      <template name="Leetcode_C_and_Cpp.h.child.1.c" file-name="${Name.replaceAll(&quot;([a-z])([A-Z]+)&quot;,&quot;$1_$2&quot;).toLowerCase()}" reformat="true" live-template-enabled="false" />
+      <template name="Leetcode_C_and_Cpp.h.child.2.cpp" file-name="${Name.replaceAll(&quot;([a-z])([A-Z]+)&quot;,&quot;$1_$2&quot;).toLowerCase()}_test" reformat="true" live-template-enabled="false" />
+    </default_templates>
+  </component>
+</application>

--- a/Jetbrains-templates/CLion/path.txt
+++ b/Jetbrains-templates/CLion/path.txt
@@ -1,0 +1,1 @@
+~/.config/JetBrains/CLion{version}/

--- a/Jetbrains-templates/Intellij/fileTemplates/Leetcode_Kotlin.kt
+++ b/Jetbrains-templates/Intellij/fileTemplates/Leetcode_Kotlin.kt
@@ -1,0 +1,13 @@
+#set ($Method = ${StringUtils.removeAndHump(${Method_name},"_")} )
+#set($Camel_case_method = "$Method.substring(0,1).toLowerCase()$Method.substring(1)")
+#if (${PACKAGE_NAME} && ${PACKAGE_NAME} != "")package ${PACKAGE_NAME}
+
+#end
+class ${Name}{
+    fun ${Camel_case_method}(input: IntArray): Int {
+        for (data in input) {
+            println(data)
+        }
+        return 0
+    }
+}

--- a/Jetbrains-templates/Intellij/fileTemplates/Leetcode_Kotlin.kt.child.0.kt
+++ b/Jetbrains-templates/Intellij/fileTemplates/Leetcode_Kotlin.kt.child.0.kt
@@ -1,0 +1,27 @@
+#set ($Test_class_name = ${Name.concat("Test")})
+#set ($Method = ${StringUtils.removeAndHump(${Method_name},"_")} )
+#set($Camel_case_method = "$Method.substring(0,1).toLowerCase()$Method.substring(1)")
+#if (${PACKAGE_NAME} && ${PACKAGE_NAME} != "")package ${PACKAGE_NAME}
+
+#end
+import org.assertj.core.api.Assertions.assertThat
+
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+internal class ${Test_class_name} {
+    companion object {
+        @JvmStatic
+        fun parametersProvider() = listOf(
+            Arguments.of(intArrayOf(0), 0),
+        )
+    }
+
+    @ParameterizedTest
+    @MethodSource("parametersProvider")
+    fun `${Camel_case_method} should return the expected value`(input: IntArray, expected: Int) {
+        val actual = ${Name}().${Camel_case_method}(input)
+        assertThat(actual).isEqualTo(expected)
+    }
+}

--- a/Jetbrains-templates/Intellij/options/file.template.settings.xml
+++ b/Jetbrains-templates/Intellij/options/file.template.settings.xml
@@ -1,0 +1,10 @@
+<application>
+  <component name="ExportableFileTemplateSettings">
+    <default_templates>
+      <template name="Leetcode_Kotlin.kt" file-name="${Name}" reformat="true" live-template-enabled="false">
+        <template name="Leetcode_Kotlin.kt.child.0.kt" file-name="${Name}Test" reformat="true" live-template-enabled="false" />
+      </template>
+      <template name="Leetcode_Kotlin.kt.child.0.kt" file-name="${Name}Test" reformat="true" live-template-enabled="false" />
+    </default_templates>
+  </component>
+</application>

--- a/Jetbrains-templates/Intellij/path.txt
+++ b/Jetbrains-templates/Intellij/path.txt
@@ -1,0 +1,1 @@
+~/.config/JetBrains/IntelliJIdea{version}/

--- a/Jetbrains-templates/PyCharm/fileTemplates/Leetcode_Python.py
+++ b/Jetbrains-templates/PyCharm/fileTemplates/Leetcode_Python.py
@@ -1,0 +1,12 @@
+#set($Class_name = ${StringUtils.removeAndHump(${Name}, "_")})
+#set ($Method = ${StringUtils.removeAndHump(${Method_name},"_")} )
+#set($Snake_case_method =${Method_name.replaceAll("([a-z])([A-Z]+)","$1_$2").toLowerCase()} )
+
+from typing import List
+
+class ${Class_name}:
+
+    def $Snake_case_method(self, values: List[int]) -> int:
+        for index, value in enumerate(values):
+            print (index, value)
+        return 0

--- a/Jetbrains-templates/PyCharm/fileTemplates/Leetcode_Python.py.child.0.py
+++ b/Jetbrains-templates/PyCharm/fileTemplates/Leetcode_Python.py.child.0.py
@@ -1,0 +1,22 @@
+#set($Class_name = ${StringUtils.removeAndHump(${Name}, "_")})
+#set($Test_class_name = ${StringUtils.removeAndHump(${Name}, "_").concat("Test")})
+#set($Method = ${Method_name.replaceAll("([a-z])([A-Z]+)","$1_$2").toLowerCase()})
+#set($Dir_path = ${DIR_PATH.concat("/").replaceAll("/","\.").concat(${Name.replaceAll("([a-z])([A-Z]+)","$1_$2").toLowerCase()})})
+import unittest
+from parameterized import parameterized
+
+from ${Dir_path} import ${Class_name}
+
+
+class ${Test_class_name}(unittest.TestCase):
+
+    @parameterized.expand([
+        ([0], 0),
+    ])
+    def test_actual_return_against_expected(self, data, expected):
+        actual = ${Class_name}().${Method}(data)
+        self.assertEqual(actual, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Jetbrains-templates/PyCharm/options/file.template.settings.xml
+++ b/Jetbrains-templates/PyCharm/options/file.template.settings.xml
@@ -1,0 +1,10 @@
+<application>
+  <component name="ExportableFileTemplateSettings">
+    <default_templates>
+      <template name="Leetcode_Python.py" file-name="${Name.replaceAll(&quot;([a-z])([A-Z]+)&quot;,&quot;$1_$2&quot;).toLowerCase()}" reformat="true" live-template-enabled="false">
+        <template name="Leetcode_Python.py.child.0.py" file-name="test_${Name.replaceAll(&quot;([a-z])([A-Z]+)&quot;,&quot;$1_$2&quot;).toLowerCase()}" reformat="true" live-template-enabled="false" />
+      </template>
+      <template name="Leetcode_Python.py.child.0.py" file-name="test_${Name.replaceAll(&quot;([a-z])([A-Z]+)&quot;,&quot;$1_$2&quot;).toLowerCase()}" reformat="true" live-template-enabled="false" />
+    </default_templates>
+  </component>
+</application>

--- a/Jetbrains-templates/PyCharm/path.txt
+++ b/Jetbrains-templates/PyCharm/path.txt
@@ -1,0 +1,1 @@
+~/.config/JetBrains/PyCharm{version}/


### PR DESCRIPTION
Adding Leetcode file creator templates for IntellijIdea(Kotlin), Clion(C and Cpp), and PyCharm Pro(Python) to increase productivity. DRY!

https://www.jetbrains.com/help/clion/using-file-and-code-templates.html#syntax
https://www.jetbrains.com/help/idea/template-data-languages.html
https://twin.sh/articles/25/intellij-increasing-productivity-using-templates

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>